### PR TITLE
add all proposals from openoffice

### DIFF
--- a/proposals/all_proposals.md
+++ b/proposals/all_proposals.md
@@ -1,0 +1,658 @@
+## TABLE OF CONTENTS
+1. [23.06.2018 Suggestion for a European Progressive Media Fund - 18-06-23](#1)
+2. [28.06.2018 Input DSC Vienna1 - 18-06-28](#2)
+3. [30.06.2018 Proposal for reform of education media- and technology-related subjects and topics in School, university as well as the public sector like libraries - 18-06-30](#3)
+4. [30.06.2018 Input DSC Vienna1 - 18-06-30](#4)
+5. [01.07.2018 Proposal for mitigating precarisation and fostering workers rights for screenworkers, digital creatives, artists, workers in the so called gig economy - 18-07-01](#5)
+6. [02.07.2018 European Autonomous Data Network - 18-07-02](#6)
+7. [02.07.2018 European Public Media Platform - 18-07-02](#7)
+8. [04.07.2018 Tech Pillar Suggestions DSC Lower Austria - 18-07-04](#8)
+9. [05.07.2018 Questionnaire submitted by Diego Naranjo (DiEM25 Belgium, NC member and Anna Mazgal) - 10-07-05](#9)
+10. [05.07.2018 National and Regional Online Voting Platform](#10)
+11. [05.07.2018 Principles for technology policy and framing the politics of technology - Joren de Wachter - 18-07-05](#11)
+12. [06.07.2018 Annette Fröhlich, Harry Unger, DSC Wiesbaden - 18-07-06](#12)
+13. [07.07.2018 Addition to proposal Autonomous Data Network Arne Babenhauserheide - 18-07-07](#13)
+14. [07.07.2018 Proposal for a „Citizen’s Research and Innovation platform“ - DSC Karlsruhe - 18.07.07](#14)
+15. [10.07.2018 Labor Intelligence / Shared Worker Governance / Cooperative Intelligence - Kate McCurdy - 18-07-10](#15)
+16. [10.07.2018 Public Digital Identity - Kate McCurdy - 18.07.10](#16)
+17. [11.07.2018 Proposal - several - Carlo von Lynx](#17)
+
+
+Speculative Topic grouping / proposal-by-topic index (Kate)
+*indicates new institution / structure proposed
+- Technology + Diversity / Inclusion
+	- 8 improve gender inclusion w/r/t tech in education
+	- 9 variety of practices to combat bias, representation quotas 
+- Technology + Labor / Worker Rights
+	- 5 rights for platform workers
+	- *15 labor intelligence (also related to research + funding) 
+- Technology + Research / Education / Innovation Funding, IP / Patents 
+	- *1, 7 EU Progressive Media Fund
+	- 3, 4, 8 require public institutions use open source software
+	- 3 education
+	- 4 open access, public funding for open source projects, abolish patents (IP)
+- Technology + Democracy in Practice
+	- 9 municipal decision-making practices 
+	- *10 National and Regional Online Voting
+	- *14 crowdsourcing citizen innovation platform (also related to research + funding)
+	- 17 liquid democracy
+- Data Security / Protection / Ownership
+	- 4, 8 regulate / ban surveillance companies
+	- *7, 13 European Autonomous Data Network
+	- *16 Public Digital Identity
+	- 12 require compensation for data generators
+	- 17 ban collection of personal data + proprietary software on personal communication devices
+	- 9 ratify Convention 108 of the Council of Europe + ePrivacy regulation 
+
+# 1 
+# 23.06.2018  Suggestion for a European Progressive Media Fund - 18-06-23 
+
+One of the suggestions I have on the media policy is the separation between content and platform. It is pretty straightforward (who write the content could not be the person which upload it on a platform) but it can be abstracted even more, to give a European perspective and ad to resist digital colonization.In short, we should produce content and it can go in a different digital platform. this will avoid to bound our community to a selected company. Imagine, if you have produced a text, your effort has been the content production. Then, is a matter of automation press "enter" and having it going to facebook, or to the Diem's blog, or to both of them? and why not elsewhere?The political proposition here is: "an entity, an institution, a political force, should not grow a community only in a convenient platform, but use all of them, automatically, as much as possible"In this way, we do not contribute in giving a unique value to the platform [ie: twitter has value because there are the tweets of donald trump], and we are not forcing our community to belong to a platform which capitalizes on users profiling.Now, let's do an effort in abstraction. Imagine the content production as a chain of tasks performed by different people, with different skills. Now I'll try to extrapolate the individual steps, they are rather hypothetical of course.A person start with a concept. a group writes a memo in flawless English after some legal/political revision. this group is producing an output (the text) and some additional metadata (stats reference, external evidence, legal analysis, links to the pictures which can be selected, contact of people, etc)the product can be translated into national languages, the translators should have access to the metadata, is for their own understanding of the context, or is additional value.then the content will look "technical" and someone else will do a copy-editing making a version more appealing for the audience.At this moment you have worked distributedly among nations, you need to have something which permits, in the least amount of formatting effort, to publish in all the platforms available.This last effort is more of an integration effort. If a technical development/research has to happen, is only in a tool which permits this content traceability, enhancing, fork-ing, translations, and the content production has to keep track of all the publications which has been doneon the platforms.
+
+<lynX> This seems to be asking for an exchange standard, not a legislation. Standard document formats however exist, also means for upload — so if the industry hasn't established a standard practice in this field maybe that's because they have no economic incentive to do so? A legal policy could make it mandatory for publishing platforms to accept a uniform simple document upload format. Not clear to me which political problem this really addresses.
+
+# 2 
+# 28.06.2018 Input DSC Vienna1 - 18-06-28 
+
+First of all, the participants determined that they do not have a profound knowledge on the topic. The topic literally is very technical and interdisciplinary as well due to its interconnection and impacts to other political fields, but we nevertheless tried our best ;-). We ask for your understanding that we are contributing to the first block of questions democratising technologies only.
+One member stated that the fact that older citizens cannot use modern technologies due to physical reasons is to be considered as highly undemocratic (e.g. reading on a smartphone). More tax-generated public investments shall be undertaken in that field (research).
+<lynX> We could require that all smartphone apps must also be usable from any computer. Technically this is already possible, but hardly anyone has an Android emulator on their laptop.
+There was a consensus that the (legal) tax evasion (company HQ in other country, example amazon, apple etc.) is specifically an issue with tech companies.
+ <lynX> EC might indeed take care of that, but it is only a secondary problem. The main problem is how the advertising and online markets were allowed to converge onto just 5 gatekeeper companies (plus 2 in China).
+Democratic participation shall be ensured by democratically legitimated representatives (with both observation function and participation in decision making, maybe even the right for a suspensory veto if she/he sees a danger for the society - until a council of experts (professors etc.) decided on the question suspended) in high-level decision-making bodies in companies. The number of seats (e.g. in a supervisory board) could be dependent on the turnover or value of the company in all over Europe (in order to avoid workarounds by the establishment of subsidiaries). Currently in Austria, public authorities (not democratically legitimated) do have sort of an observation position in banks which we considered as not sufficient.
+ <lynX> Patchworky proposal. Is there any scientific sociologic backing to doing things this way? Liquid democracy at least has http://arxiv.org/abs/1503.07723 speaking for it. Also, representation doesn't work.
+We consider the harmonization of corporate taxation in Europe as an effective and even indispensable measure to ensure justice of balance in Europe.
+ <lynX> Probably true, but do we have scientific material on the subject? And does it belong to this pillar?
+On point 5, we discovered that some solutions practiced by politics and authorities in Austria could actually be considered as an example: Funds, co-founding, investments, tax advantages/reduction for sustainable projects.
+It has been said that the practical support for such projects (logistics, office etc.) shall be supported by the public hand.
+We highly recommend the structures of the “economy for the common good” initiated by the Austrian Christian Felber. Projects will be evaluated by a multi-step process including the examination of common good impact /-orientation, feasibility etc. More information: www.ecogood.org/en/
+On question 10, a member underlined the urgent need for hard gender quotas for professors.
+ <lynX> Off-topic?
+
+# 3 
+# 30.06.2018 Proposal for reform of education media- and technology-related subjects and topics in School, university as well as the public sector like libraries - 18-06-30
+
+Regarding the changes in technology and society influenced by digitization, the internet, social media etc. the educational sector has to adopt existing knowledge and practices to teach children, youth and students skills and understanding to navigate in the contemporary digital world.
+As has been shown the technological means that have come into existence in the last decades have been exploited by the industrial-entertainment-military complex as well as by states to undermine existing liberties and the maturity (Mündigkeit) of both societies and individuals. This is has to be acknowledged as existentially undemocratic by politicians, educators and media outlets alike. All actors representing civil society, democratic functions or values have to take on their “Bildungsauftrag”, which has been dramatically neglected until now to foster democratic technologies. By this we mean software and hardware solutions that aren't corrupted by neocapitalist, geopolitical, military means. For instance this can mean the following:
+
+SCHOOLS
+
+Informatics, (New) Media
+
+Curriculum has to be accompanied by teaching skills in and understanding of digital and especially cryptographic tools (open source alternatives to basic software like OSs, alternatives to commercial service providers like GAFAM, browser extension or crypto-browsers, tool to encrypt communication like encrypted mailing, messaging, password managers etc.)
+
+<lynX> If we let humanity live on in the mine field of an unregulated Internet, then we need to spend billions in educating the teachers so that they actually know what they are talking about. Probably easier to change the Internet so that it no longer is a mine field. Then *nobody* has to learn encryption tools, and *nobody* has to understand why they are necessary. The "alternative" would become the default as mandated by legislation (#ObCrypto).
+
+Social science
+
+Curriculum has to offer a focus media science that is up to date to accompany the practical skills. Lessons in Philosophy of technology where schools don't have philosophy classes.
+
+Art
+
+A focus on New Media has to be offered. E. G. teaching kids to cut videos to gain an understanding of how media are essentially montages. Elaborating on skills and methods in a creative way.
+
+PUBLIC SECTOR
+
+Institutions
+
+Public places and institutions are likewise able to foster and implement more democratic technologies. For instance libraries can set up their systems in a more open source secure way while at the same time spreading knowledge and best practices to its users. A good example for this is the American Library Freedom Project (https://libraryfreedomproject.org/)
+
+Public media, public advertisement
+
+Another place to push back the dominance of corporate power and abuse of digital technologies by other players is to oppose their all encompassing presence in media and advertising (TV, Internet, Public sphere). There have to be state- or EU funded campaigns advocating for the above mentioned solutions and their essential importance for a free, democratic and also economically more just society - think platform and surveillance capitalism where, corporations mine data to generate exorbitant surplusses, without paying taxes and drastically changing “the game” for unaware citizens respectively, in corporate talk, users.
+
+<lynX> Let's forbid unethical surveillance capitalism rather than de-facto accepting it by running (desperate) campaigns for the "alternatives."
+
+# 4 
+# 30.06.2018 Input DSC Vienna1 - 18-06-30
+
+With the rapidly rising importance of science and technology, the importance of their democratic control is also growing. Most of basic research is still financed by the public, either directly done by public institutions are in private institutions but partly funded via public grants. Only when it comes to making final products out of this, this is done mostly in the private realm. There, most patent applications are done. Thus, most of the costs for research are paid by the public while most gains are privatized. The current patent-system is extremely harmful. The most logical conclusion would be to abolish the patent-system all together: This way everyone can profit from the common knowledge.
+<lynX> Patents also have their useful aspects. I would suggest to work on societal taxes and dividends for redistribution, this way the gains the corps had through public research flows back to the citizen. See also 'European New Deal'.
+
+As we can see, there is a trend towards big monopoly power within the tech industry: Google, Microsoft, Apple, Facebook, Amazon. The reason for this is, that with these new technologies cooperation is a much more efficient way of production then competition. So these large corporations have the advantage of being able to have cooperation within their company. 
+<lynX> This is not an accurate description on how the big 5 became monopolies.
+
+Of course the monopoly power is extremely harmful and dangerous. Thus we need to find ways to promote cooperative production without the need for mega-corporation. One extremely successful model here is open-source/free software: It encourages cooperation: while everyone can benefit from the existing base of software, the model also encourages the contribution to this pool.
+<lynX> Free/Open Source software was one of the winning ingredients of Google and subsequent monopolists. When it came to making a product they moved the code to the private realm, just like it is described with research above. FLOSS alone is not the solution, it needs supporting legislation.
+
+Free/Open Source software is also the only way to guarantee real security on the net: Only when the code is open to be studied by everyone can we be sure that there are no back-doors hidden in the code.Thus we need to foster the model of Free Software/Open Source and also try to apply it to other fields of science and technology. With the rise of 3D-Printing and other computerized technologies, the realm of physical production becomes more and more similar to that of software production. Thus the same rules make sense there.Political demands here would be:* Make Free Software/Open Source mandatory for all public institutions and publicly funded projects.* Public financing of strategic free software/open-source projects.* Demand "Open Access" for all scientific research.* Abolish the patent system. (Gradually removing the scope and lenght of patent zero). Instead we need to gradually replace it with a system, where we demand that all products sold need to come with full receipts, source code, descriptions of production processes, etc. * The above is also in line with the "Right to Repair". Products need to be constructed in a way so that they can be repaired and come with full schematics. (Years ago every TV-set came with full schematics, now this is rather rare).* As a preliminary step we need to demand interoperability: Full documentation of all interfaces. (In the end not only the surface (interfaces) should be open but the underlying code as well. See that demands above).
+<lynX> DiEM is not in government, therefore it should not confuse electorate with "preliminary" steps. It should promote the long-term vision for fair technology that doesn't suck. Proprietary technology should not be legal for any societally critical applications.
+
+Data Protection and Privacy
+
+As pointed out above: The only real protection is with free/open source software. When it comes to the evasion of our privacy there are 2 major factors here:1.) spying by governments via there secret service organisations.2.) private data collection by corporations.As for 2.: The main motivation for private data collection is advertising.Advertising in itself is harmful to our society. It creates artificial demands. Its only product is the creation of discontent. People wanting more and not being happy with what they have. As the ecologic footprint of this is destroying our environment we need to cut down on the logic that forces constant growth anyway. Thus we should either put high taxes on advertising, or outright outlaw it. Also cutting down on trademark protection should remove incentives for advertising. – 
+
+<lynX> Outlawing advertising is a worthwhile thought. It is rarely ever used to inform us of the existence of some new product and most of the time manipulating us, especially everyone below 20 years of age or so (when advertising actually works best — check research on the subject). This is beyond the scope of our pillar, but we could certainly forbid all kinds of surveillance-based and individualised advertisement built on psychological manipulation by disabling certain features of HTTP and Javascript *by law*. No web browser is allowed to support them. No web server in Europe must try to employ them.
+
+A second motivation for private data-collection is the monetization of digital content. In order to charge money for some content, the content needs to be behind a pay-wall with personalized login. While in the old days, TV was broadcast and then could be received anonymously on a TV or Radio set. We should try to get back to this model: Cutting down on the Copyright protection so that content can be freely shared on the Internet without the need to have personalized logins. Content creators could be rewarded by anonymous statistical methods that measure of popularity of content. Also we should strive for public sponsoring of quality content.
+
+<lynX> Copyright abolition would not solve this problem. Content goes viral using one specific URL and whoever has that copy makes all the money. Still, the idea of going back to "broadcast" is very good and the way to achieve could be to (a) make it mandatory to distribute websites by multicast pubsub instead of HTTP (see https://secushare.org/pubsub or IPFS for that), (b) make targeted advertising illegal and (c) introduce a mandatory anonymous micropayment system by which *any* article can be bought anonymously for a few cents. See https://taler.net for the most promising payment system in that regard.
+
+As for 1.): Besides directly using their power over corporations to install backdoors into their products the intelligence apparatus pays hackers for so called zero day exploits (Knowledge about flaws in security of products that are not known to the public or the vendor of the product and thus can not be fixed by the vendor). Thus these government organizations that should careabout our security actually make us less secure. The practice of paying for exploits that are not disclosed to the public needs to be stopped immediately. Instead we need to publicly fund security research and could offer bounties to individuals who help to find security vulnerabilities.
+
+<lynX> Yes, and forbid proprietary code in all societally essential systems, therefore giving any programmer on Earth a decent chance to find vulnerabilities by reading *source code* rather than disassembling machine code.
+
+Social media systems are useful and popular, yet they are a risk to our privacy. We need a system where it is safe for us to share whatever we want with our family and friends without the risk to share it with third parties. We need public funding for alternative social media systems which are built not for profit and which are based on decentralized systems and strong cryptography to protect our data from getting into the wrong hands.
+
+<lynX> Oh yeah! We need funding to *create* a truly distributed and private social network. None of the existing softwares can actually replace Facebook *technically*. In most cases they are just yet another server you have to trust. See https://secushare.org
+
+We also need to have the guaranteed right to use pseudonym accounts online where we want to.
+<lynX> Why? And is it enough if it is just a right and not an obligation? For the defense of democracy it probably must be mandatory to anonymise or at least pseudonymise digital activity.
+
+Even with all the measures above, some of the new technologies inevitably lead to situations where we leave ever more digital traces of our life (e.g. the existence of cell-phones requires that the cell-phones log into the next-cell phone tower - thus we inevitably leave a trace of our movement.)
+<lynX> This can actually be solved technically and should be mandated by law. See https://youbroketheinternet.org/programme for details.
+
+So if we as citizens and consumers become more transparent, in order to keep the balance of power, we also need to ask for more transparency on the other side. Strong transparency of governmental and corporate power is a must. We need strong protection of whistleblowers but also much deeper and more detailed monitoring of governments and corporations. (E.g. all financial transactions above a certain threshold need to be publicly recorded.)
+
+<lynX> I wouldn't want DiEM25 to make such a statement as it would accept and acknowledge that citizen and consumers become more transparent while that isn't actually necessary for anything, it has no societal benefit and should be forbidden by law. Still, even if we defend the privacy of people it is still important for humanity to improve transparency of corporations (other pillar however).
+
+# 5 
+# 01.07.2018 Proposal for mitigating precarisation and fostering workers rights for screenworkers, digital creatives, artists, workers in the so called gig economy - 18-07-01
+
+The change digitalisation has brought about in every aspect of our lives has restructured, is
+restructuring and will continue to restructure many people's work and, to use a term that was
+probably coined in the business world, their work-life-balance.
+Besides alleged benefits like more flexibility and individuality this has shown a lot of negative or
+unsettling effects for workers rights that had to be fought for in previous iterations of class struggle.
+Just like workers in the factories of industrial times, “screenworkers”, digital creatives, artists and other freelancers, like workers in the “gig economy” (think UBER) are atomized and unorganized, disabling them to collectively change the rules of the game. This is a trend that spreads to other groups of society, as work is continually being technologically transformed, and is becoming the new normal.
+Therefore a progressive discussion has to enter the political mainstream about these altered
+circumstances. This can for instance mean, as journalist John Harris writes in the Guardian:
+"...We urgently need a new Politics of Home. …"
+"More generally, the need for a distinction between work and downtime should enter the political vocabulary as a fundamental right, and the organisations dedicated to trying to enforce it – most notably, the network of small freelance unions that are dotted across Europe and the US – need to be encouraged and assisted."
+One of his concerns is how digital nomadism - hyper-flexibility and availability being one
+precondition of making it in this new normal - casts away “any meaningful notion of home”. While this might be labelled as romantic by others, he points to the erosion of the protection of basic psychological or emotional needs (besides the already widely discussed, but mostly unanswered economical downsides and hardships). Technological progress however welcome, does not mean that people directly influenced by it in a negative way have no say in what are just working conditions. The dominant normative influence of the tech industry and tech giants has to be faced by giving these workers a voice - respectively lending them an ear acknowledging their existence - political tools and political support.
+When jobs that fit into this category become the new normal, people working in these jobs should receive a contemporary standard for basic workers' rights, legal methods or tools to empower them to claim and defend these rights if not already existing.
+If not already part of it this roughly outlined problem could be integrated into DiEMs European
+New Deal. More concrete aspects can however not be outlined in this proposal and require a
+discussion by more specialized participants.
+
+# 6 
+# 02.07.2018 European Autonomous Data Network - 18-07-02
+
+Problem:
+
+Right now Cloud Services are centralized, monopolized and often unsecure. The Internet giants are harvesting our data and a centralized server structure provides a ready-made framework for government surveillance. We are not safe on company servers.
+
+Solution:
+
+A decentralised, anonymous, autonomous, encrypted peer-to-peer-network (as opposed to the Siren Servers described by Lanier ).
+This peer-to-peer has to incorporate the following specifications:
+
+→ All data on the network is encrypted (even sites and blogs – decrypted upon access)
+→ Serverless and decentralized
+→ The network creates and maintains itself automatically
+→ Ensures Anonymity
+→ Ensures Net Neutrality
+→ A proxy node obfuscates the clients' (and vaults) location (= IP address in the current broken Internet)
+→ Data is stored on hardware and transferred via bandwidth provided by users (so-called Farmers on so-called Vaults)
+→ Allows to implement a micropayment system (e.g. users pay for data storage) — Incentive!
+→ individual files are split up into pieces (e.g. 1 MByte) , encrypted and spread out over the network (tech detail)
+→ Popular Data is being spread increasingly (to where it is demanded) ensuring a growing availability for e.g. popular websites
+→ no person has a complete overview over the network (given a minimum size)
+→ The bigger the network becomes, the more secure it will get
+→ Older Vaults will earn more credibility by doing Proof of Resource (Bandwidth / CPU-Power / Low Downtime) — (tech detail, could also be solved differently)
+Demands to public infrastructure:
+→ The EU has to set up a European Safe Networking Fund that encourages research on an open-source and easy-to-use solution implementing the specifications mentioned above.
+→ The EU provides bootstrap servers and minimum amount of storage capacity (storing encrypted data chunks) to get the network up and running.
+What else?
+The Farmers (users that provide hardware and bandwidth) don’t know what they are storing
+The User accesses the network using a Client (e.g. embedded in a Browser). Every user has a so-called Vault that allows the network to store data on their devices → Farmers
+(Providing storage capacity, computation and bandwidth could be linked to virtual currency earnings).
+ <lynX> Spare a few details that are too detailed you just pretty accurately described the GNUnet/secushare project.  <3  The YBTI proposals for legislation aim at obtaining this kind of Internet instead of the current borken one. Instead of asking money to be spent in making this system we recommend to make it a necessary requirement so that the entire industry MUST work on solving this challenge: the challenge for an ethically acceptable Internet.
+
+# 7 
+# 02.07.2018 European Public Media Platform - 18-07-02
+
+Problem:
+
+A lot of European countries run a bunch of online content platforms (Mediathek, Médiathèque, iPlayer, TV a la Carta etc.). These platforms are delivering content produced and particularly owned by public stations. So far only Germany and France have managed to provide a bilingual content platform (arte), while there is an ecosystem of hand-crafted solutions for almost every regional station - at least in Germany.
+
+Solution:
+
+The European Union is in need of a multilingual content platform that stores and delivers content produced by the distinct public stations to all European citizens. It would deliver subtitled and/or voiced-over content produced or licensed by EU public entities to enrich a pan-European public debate in all European languages.
+
+Link to the upcoming Vision for Culture-Pillar:
+
+To ensure that content producers are being paid a fair amount to deliver European-wide accessible (audio-visual) content, new license models will have to be crafted. To encourage this an entity called European Progressive Media Fund (EPMF) would search and identify national or regional projects and fund them with eg. 10-20% of the productions costs (additional to what other public entities are paying). In return the European Public Media Platform would receive limited licenses to translate into the European languages and broadcast this content in the entire EU.
+The EPMF would concentrate on news, feature films, podcasts, documentaries and radio programs that enrich a progressive, democratic and pluralistic transnational debate and provide European citizens with a large variety of regional, municipal and national standpoints within the EU.
+The EMPF would run on a democratically controlled, decentralised and anonymously accessible infrastructure.
+
+Educational Games Fund (Link to Educational Proposal by C. Kasners):
+
+This will be part of the European Progressive Media Fund (EPMF).
+Videogames are probably the most underestimated cultural form in the 21st Century. Hundreds of Millions of Gamers shape their imaginations and desires in front of the screen. While it could be argued that games are apolitical it might be useful to have a closer look of what is happening to the players during their screen time. Are games in which you have to protect your virtual borders and to conquer the opponents territory only reflecting the ugly truth of human affairs? Or is the way we are thinking about the world also shaped by video games? The limits of our language are the limits of our world, said Wittgenstein. 
+We propose a European funding for the development of progressive, democratic and/or educational forms of video games, interactive adventures, Web documentaries and other innovative forms of storytelling. 
+See for instance: Jeu d'influences, Hackstage Pass, Papers Please, Fort McMoney
+
+# 8 
+# 04.07.2018 Tech Pillar Suggestions DSC Lower Austria - 18-07-04
+
+My input is grouped in chapters which me thinks should be part of the Tech Pillar.
+Most emphasis should be given to consequences of tech developments for average 
+people rather than ideas to develop new technologies and supporting nerds.
+
+Surveillance capitalism and its economic and political implications
+
+- explain mechanisms of data collection, data exchange, contributing companies like  Oracle, Acxiom, Google, Microsoft, Facebook, banks, insurances, telecoms ...
+- how are collected data used in advertising, risk assessment, customer management, ...
+- what are the negative economic consequences for users of pervasive data collection
+
+A wide range of data and analytics companies in marketing, customer management and risk analytics seamlessly gather, analyze, share, and trade consumer data as well as combine it with further information from thousands of other companies. While the data and analytics industry provides the means to deploy these powerful technologies, businesses in many industries equally contribute both to intensifying the amount and detail of the collected data and the ability to utilize it. An excellent overview about methods and implication of a developing society of pervasive digital social control was compiled by Wolfie Christl and can be found here:
+http://crackedlabs.org/en/corporate-surveillance/
+
+This report finds that the networks of online platforms, advertising technology providers, data brokers, and other businesses can now monitor, recognize, and analyze individuals in many life situations. Information about individuals’ personal characteristics and behaviors is linked, combined, and utilized across companies, databases, platforms, devices, and services in real-time. With the actors guided only by economic goals, a data environment has emerged in which individuals are constantly surveyed and evaluated, categorized and grouped, rated and ranked, numbered and quantified, included or excluded, and, as a result, treated differently.
+
+- surveillance capitalism has developed meanwhile massive political implications 
+This is nicely described in 'Cory Doctorow: Zuck’s Empire of Oily Rags': 
+http://locusmag.com/2018/07/cory-doctorow-zucks-empire-of-oily-rags/
+
+Given enough surveillance, companies can sell us anything: Brexit, Trump, ethnic 
+cleansing in Myanmar, and successful election bids for absolute bastards like Turkey’s Erdogan and Hungary’s Orban.
+
+- develop a political strategy against surveillance resp its implications and usage some  ideas: 
+- break up integrated enterprises like Google, Facebook, Oracle, advertising 
+conglomerats (https://apps.bostonglobe.com/opinion/graphics/2018/06/break-google/)
+- prevent trading and combining data with competition laws and criminal laws
+- curb data collection beyond GDPR
+
+ <lynX> Breaking up the monopolists would need to be repeated yearly as the digital market tends to recreate new monopolists. The best way to prevent trading of data is to not let anyone *have* any data to trade — otherwise trade will happen, either legally or in the darknet, simply because the data is there and there is no evidence of it being abused or stolen.
+
+
+Platform economy and two-sided markets
+
+Two sided markets are markets in which there isn't a simple relationship between a 
+business and its customers. Instead, the profit model involves a business mediating 
+between two different groups, and making its money from bringing the two together.
+This is the basis of the platform economy. 
+See also https://mobile.twitter.com/henryfarrell/status/1011315278741954560
+
+- platform companies like Facebook or Google need to be treated along the rules of  surveillance capitalism
+
+They provide services to individuals to serve those individuals up to advertisers. But if 
+they cannot demand personal data from their users as a condition, then they don't have anything valuable to provide to their real customers any more. See Max Schrems cases against Facebook.
+
+- platform companies like AirBnb, Uber, Booking etc need different treatment. They  are  collecting data as well but have in many cases severe implications for local economies.  Like AirBnb reduces available living or housing space thus raising the costs of living considerably.
+
+Additional regulation will be required to curb negative effects of this sort of platforms for local economies and the living costs of local people. Taxation of this sort of enterprises must be raised
+to levels of small local firms.
+
+<lynX> Yes, but how?
+
+Technology and labor
+
+Cross references to the respective contents of the European New Deal: SHARING THE RETURNS TO CAPITAL: In the increasingly digital economy, capital goods are increasingly produced collectively but their returns continue to be privatised. As Europe becomes more technologically advanced, to avoid stagnation and discontent it must implement policies for sharing amongst all its citizens the dividends from digitization and automation. Other important issues are:
+
+- weekly  and daily work time reduction 
+- current EU rules require maximum of 48 hours per week averaged over a period of 17  weeks suggestions: max 10 hours per day; max 40 hours per week averaged over 10  weeks; regular work time reduced to 7 hours per day and 35 hours per week (???) all with  full wage compensation
+- reduce online availability esp. of white collar workers
+- support creation of unions or other representation of Single Person Businesses; 
+develop  social networks like unemployment insurance, pregnancy leave, health  insurance, pension insurance
+
+Female Tech, Woman in Technology, Diversity
+
+Women are grossly underrepresented in tech jobs. At least in western countries. However in countries of the former socialist block there are many more women graduating from technical studies as well as working in tech jobs. This is reporting amongst others by dy the study dean 
+of the faculty of informatics at the Technical University of Vienna Hilda Tellioglu and Maria Zesch former CEO of T-Mobile Croatia. Part of the reason might be inadequate methods of teaching especially in mathematics. I know of Bostonian families who send their kids to schools teaching mathematics with methodology and curricula imported from Russia.
+
+
+
+I am not aware of studies about the reasons of the gender gap in tech. If there are none 
+
+- studies need to be carried out to find out the reasons in the teaching methods for the  gender gap in tech
+- improvement of tech teaching methodology from grammar schools to universities 
+with special gender bias and encouraging und promoting girls and women
+- initiating programs like "Female Entrepreneurship Initiative Programme"
+
+Make Open Source mandatory in governmental IT
+
+There are three main reasons for using Open Source software:
+- independence from non-European suppliers
+- security reasons with unknown content of proprietary software
+- develop local know how and create local revenue
+
+# 9 
+# 05.07.2018 Questionnaire submitted by Diego Naranjo (DiEM25 Belgium, NC member and Anna Mazgal) - 10-07-05
+
+Questions:
+
+Democratising technologies
+
+1. Can you name practices and problems in any technology that you and others see as especially "undemocratic"?
+
+There are a number of problems in relation with technology that have existed either since the emergence of a given technology (insecure mobile infrastructure) or that have evolved in an unsustainable way (from the Open Internet to silos of privately owned social networks). Some specific problems in different fields are:
+
+Data Protection and Privacy:
+
+In the field of data protection and privacy, there are many issues that have been on the spotlight in recent years: The Snowden revelations and some of the Wikileaks leaks revealed the magnitude of surveillance by public and private actors. Scandals at Facebook (most recently the Cambridge Analytica usage of personal data enabled by Facebook) brought into the light problems of profiling for political purposes and abuses of personal data without the knowledge of both users and non-users of these services. In the short-term, the most ambitious implementation of the General Data Protection Regulation (GDPR) should be encouraged. In the medium-term, in order to ensure a global approach, we should push non-EU states to facilitate the expansion of similar standards via the signature and ratification by all States of the Convention 108 of the Council of Europe.
+ <lynX> This assumes GDPR actually achieves the goal. See https://youbroketheinternet.org/GDPR for a criticism why GDPR may in large part fail to actually achieve the intended goals.
+The wide usage of insecure communications (unencrypted emails and messenger apps (so-called OTTs), sms, others) have created the standard of communication for unaware citizens. In the very short-term (before end of 2018), the ePrivacy Regulation needs to be adopted with, among other clauses, one ensuring privacy by design and by default in all hardware and software used in the EU. 
+
+Oligopolies/Duopolies: 
+
+Nowadays (Google, Amazon, Facebook, Apple and Microsoft) GAFAM are by far the main actors that increasingly intermediate all aspects of our activity online. These companies are where internet and critical parts of the technology we use are developed. It has far-reaching implications: for example the existing duopoly of online advertisers (Facebook and Google) creates a huge pressure on online media and therefore affects how our societies are informed about public debate on crucial issues. In the short term competition law, hand in hand with strong data protection and privacy regulations, should be put in place immediately. In the longer term, alternatives to such tech giants should be encouraged and made available by the public sector.
+
+Right to science/Access to culture: 
+
+There is an urgent need to reduce maximalists approaches to copyright that favor widening of proprietary rights at the expense of noncommercial user activity. They jeopardize participation in culture and allow for introducing censorship with the excuse of fighting piracy, as the current discussions on the copyright Directive proposal in the EU show with the proposal of upload filters.
+
+2. What can be done to foster the privacy of European citizens and to protect their data from misuse by private corporations, states and third parties?
+
+Enhance data protection regulations worldwide (Convention 108 of the Council of Europe); ban data protection in trade agreements; ensure privacy regulations (in the EU: ePrivacy Regulation) ban limitless online and offline tracking, tracking walls, tracking cookies; work to improve our electronic communications to move away from current insecure communications by, for example, investing in ready-to-use encryption technologies for emails and make data protection and privacy by design and by default a requirement for all hardware and software sold in the EU.
+
+3. Which models of data ownership and governance can democratise the production and usage of data? When should data be open?
+
+Personal data needs to be protected with the highest protections we can achieve (Convention 108, GDPR….). Non-personal data should be open whenever possible so that everyone can re-use it. Specially, data produced by public institutions needs to be made open by default. We do not recommend models based on “data ownership” that envision the possibility to to trade personal data for services and benefits. It would affect the vunlnerable populations that have less resources and digital literacy and therefore enable forced trade of fundamental rights.
+
+4. Which regulations can constrain the growing Internet monopolies (Google, Amazon, …) and make them accountable to democratic decisions? (without creating ridiculous constrains for the small scale and non-profit internet ecosphere)
+
+Convention 108 and GDPR for data protection; ePrivacy Regulation for privacy; modernisation of copyright laws and in the medium-term a revision of the Berne Convention for copyright towards ensuring that the noncommercial user activity that does not infringe interestes of creators is not criminalised.
+
+5. How can alternative economic models such as co-ops and commons projects be fostered in all technology?
+
+Economic models such as co-ops and commons projects face great opportunities of growth online because they are by nature decentralised and participatory. What endangeres their thriving is the increasingly centralised model of services that is labeled as sharing aconomy but in practice is a rental model where rights and property are privatised (by infrastructure providers) while the risk and costs are socialised (by actual service providers and their clients to an extent). The so called “uberisation” of participatory economy should be resisted by building services that are truly owned by their providers who also collectively own the technological infrastructure though which users access these services. In that way the infrastructure-and-service provider is participating in the benefits, including ownership of the shares and the risks are managed collectively without an incentive to transfer them to frontline service providers. Open ecosystems, be it for content (free and open licensing) or for providing infrastructure (free and open software) ensure that the concentration is prevented by their non-exclusive and non-proprietary character.
+
+6. What alternative models of funding for technologies and innovations should come into existence?
+
+If research of software is made with public money, the code needs to be made open/free. The public sector should encourage the availability of alternatives to tech monopolies/oligopolies (email providers, social networks, etc.) by creating rules fostering the implementation standards that can be used by decentralised FLOSS alternatives. By doing so, anyone could for example interact in Twitter-like platforms by using the same standards while perhaps using different clients.
+
+7. Do you know existing examples of the democratic shaping and/or use of any technologies?
+
+Free Software platforms, projects and applications such as GitLab, TOR, Firefox and others. These platforms allow for greater participation in creating transparent code that can be utilised to build projects on top of the core products that are being developed. Communications are being democratised with the creation and use of apps that empower citizens by protecting their privacy: Signal, Wire, Linux distributions and others.
+
+8. How can we balance properly the interests of all stakeholders in relation to technology? Those who research it. Those who develop it. Those who make applications for it. Those who employ it. Those who use it. Those who distribute it. Those who pay for it. Those who need it. Those who get damaged by it. Those who are afraid of it.
+
+This question allows for a longer dissertation that this paper allows. In short, the key to create a better balance is to open a debate where all these groups, with special emphasis of the underrepresented and digitally excluded, have a voice. Currently, as the debate on EU copyright reform shows, the debate is between globalized market giants: the global entertainment industry on one hand and dominating platforms on the other. The perspective of citizens needs to be visible and articulated by their elected representatives on the national and pan-European level.
+
+9. How do we create a story of democratic empowerment with technology, rather than the sterile pro-contra luddite/technofile intellectual trap?
+
+Privacy by design and by default must be made mandatory for all hardware and software available to the public, for example by ensuring it in the ongoing debate on the ePrivacy Regulation. The use of Free and Open Software by public institutions should be mandatory.
+We need to support legislation to be launched in the next EC/EC term where it is made mandatory that software made with public money needs is licensed under an open license: public money, public code.
+
+10. How can make sure women are included and able to fully participate in the process of democratising technologies?
+
+This issue requires multi-level response, that comprises of the building inclusive technologies and spaces for debate in practice; but also systemic encouragement and introduction of women and girls into STEM formal and informal education. As in any issue of public interest the parity of voices and experiences should be safeguarded and promoted. Both soft and hard measures should be implemented in building the culture of non-discrimination and inclusiveness, with procedures helping acquiring the fair approach (such as anonymised reviews of performance such as code writing to avoid gender-based bias). Both public institutions and companies should be incentivised and praised for real efforts to introduce gender balance and equity and building structures with higher retention of female employees in tech fields. At the level of general public debate where technology becomes a tool in accelerating public interventions a representation of women and minorities as contributors, experts and implementers should be ensured to create a balanced response to societal problems.
+
+Democratising Research and Innovation
+
+1. Can you name practices and problems in research and innovation that you and others see as especially "undemocratic"?
+
+Oligopoly system for academic publishing; music and film industry; collecting societies.
+
+2. What can be done to reorient research towards the public good and to democratise research and innovation?
+
+Male mandatory open licenses for studies, software, cultural works, etc…. Funded with public money. Breaking the established monopolies in science publishing by ensuring that alternative (open preferably) publications can be used in peer-review systems In the short-term, prevent that text and data mining methods of assisting research and building knowledge from becoming a part of copyright regime in the EU, in accordance with the rule that the right to read is the right to mine.
+
+3. The European Union is a major funder of research and innovation - what can be done to make the funding processes more democratic and accountable to European citizens and their expectations for research?
+
+See 2.
+
+4. How can we reform copyright to be compatible with democracy?
+
+In the short-term, harmonise exceptions and limitations in Europe and fix all copyfails (https://edri.org/copyfails/). In the medium-term advocate in the WIPO towards the reform of the Berne Convention and eliminate or reform aspects of it which do neither encourage creation (such as the +50 years of protection for copyright after the death of the author) nor protect authors.
+
+5. Who should benefit from the public/commons investment into technology, and how?
+
+No comments.
+
+6. How can diversity and inclusion in research and innovation be fostered?
+
+No comments.
+
+7. How to foster inclusive and democratic technological creativity and innovation?
+
+This issue requires multi-level response, that comprises of the building inclusive technologies and spaces for debate in practice; but also systemic encouragement and introduction of minority and underprivileged groups into STEM formal and informal education. As in any issue of public interest the parity of voices and experiences should be safeguarded and promoted. Both soft and hard measures should be implemented in building the culture of non-discrimination and inclusiveness, with procedures helping acquiring the fair approach (such as anonymised reviews of performance such as code writing to avoid race or class bias for example). Both public institutions and companies should be incentivised and praised for effective documented efforts to introduce diversity and equity and building structures with higher retention of employees of diverse backgrounds in research, tech and R&D in general. At the level of general public debate where research and innovation becomes a tool in accelerating public interventions a representation of minorities and underprivileged/marginalised communitites as contributors, experts and implementers should be ensured to create a balanced response to societal problems.
+
+8. Which organisations should be supported because they embody a democratic approach to innovation?
+
+Free Software communities and projects.
+Human rights and social justice organisations that need to integrate digital literacy into their work to adress the key issues where technology and innovation play increasing role but their applications go unchecked due to lack of experience, such as predictive policing, social and racial profiling, tech-assisted population profiling for census and statistical purposes creating mega-databases, big-data based evidence building to tackle social problems with obscure technology tools, etc. These groups need to understand the positive aspects of introducing tech tools into their field of work by public actors, as well as the negative consequences the obscurity of these tools and unpreparedness of the public sector to properly assess their utility and impact.
+
+9. Do you know existing examples of democratic research and innovation processes?
+
+See 8
+
+10. How do we fix the peer-review system?
+
+By overview of the current scientific publishing system (there is data on how it malfunctions), inviting scientists and universities to debate the diagnosis and jointly look for solutions. It might be necessary to look on the problem from the point of the anti-trust law. However, without empowering scientists and jointly creating frameworks of reference that will prevent coercing them into the pay-forpublication – pay-for-access model, it will not work. Politicians and decisionmakers need to show the will to break up the powerful lobby (and with the powerful lobby as well)
+
+11. How do we make sure that the results of research and innovation become beneficial to all stakeholders in society?
+
+See 2 and 5
+
+12. How do we create a process to identify roadblocks to research and innovation, and then find solutions to remedy those roadblocks?
+
+No comments
+
+Democratising Infrastructures
+
+1. Can you name practices and problems in infrastructures that you and others see as especially “undemocratic"?
+
+See the response to the first question in the first section.
+
+2. How can infrastructures (energy grid, energy production, mobility, digital, etc.) be democratised and their governance be oriented towards a green transition?
+
+No comments.
+
+3. How can municipalities gain sovereignty over their infrastructures?
+
+In the short-term implement the use of free software, open formats and creative commons licenses, open data models by local municipalities , foreseeing a as soon as it is techincally possible (within the next 5 years), taking into account the necessary period of adaptation and prepare a medium-term strategy to adapt all inter-related technological infrastructures to be able to be interoperable at local, regional and national levels. In addition to these are tools some other solutions are reinforcement of urban movements and activists that can either meaningfully influence decision-makers or become elected representatives of their communities. The use of the tools listed above should be however accompanied with redesigning governance models into more open and participatory, or else the benefits coming from their use will benefit the private proprietary systems that lock in value from data and opportunities that open models create. In doing so, municipalities should in the short-term should make public all related existing public-private partnerships and collaborations, where services created would be audited from the point of their openness, and ensure social return on investment exceeding their nominal goals. For example using tech tools to run statistical modeling for issues affecting the population should not allow feeding on personal data and profiling. Smart city solutions should turn the technologies and enhancement used into public property and under public control and not privatise public spaces by their obscurity, proprietary licensing, etc.
+
+4. Do you know existing examples of the democratic governance of infrastructures?
+
+Implement in the short-term participatory budgeting where inhabitants can give ideas on how to spend a portion of the municipal budget in their local community and also vote on those of them that they find the most valuable or necessary. All rules and laws that permit citizens to participate, record and disseminate meetings and debates of council sessions etc., are a good tool in enforcing greater accountability. In the medium-term we need to make sure that public consultations are introduced as part of the decision-making processes, where the consultations are timely, unbiased, easy to access and reported upon as to who took part and how the input has been used (or not and why) bring democratisation and create greater identification of the community with the end result, even if not all postulates have been delivered upon.
+
+
+# 10 
+# 05.07.2018 National and Regional Online Voting Platform
+
+Proposal for the Technological Sovereignty Pillar of DiEM25 from Christos Piniatides - 180705
+
+Europe will be democratised. Or it will disintegrate!
+
+These are the first words in our Manifesto. DiEM25 has since delivered an Online Voting Platform that fosters:
+1. Democratic dialogue inshaping our proposals.
+2. Legitimacy by allowing members to vote on all major policies and documents.
+
+The only problem is that the voting results are not verifiable as it’s a closed system.
+Most governments in the EU only have one option when seeking legitimacy from the public on 
+major policy: referendums. These cost a lot and take a lot of time to prepare and to participate in. As a result, they can be used as an excuse to keep the population outside of the decision-making process.
+Proposal
+
+I propose that DiEM25’s policy should be to promote an Online Voting Platform for democracies on the national and regional levels including cities, municipalities etc.
+For example, when and if MeRA25 is elected in Greece, it will have the democratic legitimacy to implement the 7 policies mentioned in its Manifesto and on which they will campaign. When other major policy issues arise, there should be an Online Voting Platform which they can use to 
+secure public democratic legitimacy and improve the public’s participation in the Democratic process. This will greatly improve the public’s trust in Democracy which is at all-time low.
+A possible implementation would be to tie this Online Voting Platform with the Public Digital Payments Platform (PDPP) from the European Green New Deal, in the form of a smartphone app and website portal. A positive side-effect would be that the public would correlate Democracy and voting with the process of money creation, a public good.
+
+Finally a piece of free software called CHVote, developed in Switzerland by the Geneva Canton, is a possible option when building the Online Voting Platform. It provides end-to-end encryption and voter identity certification.
+
+This proposal will be discussed by the Prague English DSC and possibly improved during the 1st
+Green paper processif it enters the paper. 
+ 
+ 
+ 
+# 11 
+## 05.07.2018 Principles for technology policy and framing the politics of technology - Joren de Wachter - 18-07-05
+
+1. Technology serves humanity, not the other way around.
+
+What does that mean?
+
+Technological development is not a goal in itself. Technology exists to serve human progress. When technology harms humanity, it should be regulated, restricted, or even banned. And all aspects of humanity, such as welfare, health, ease of use, values, and social relationships of all humans have to be taken into account. DiEM25 firmly supports human rights in the face of technology – humans, all humans, come first, and technology second.
+
+2. Technology can be awesome.
+
+What does that mean?
+
+Technological development can be a formidable force for good. Technology is a key contributor to our civilization’s ability to provide health, welfare, social interaction, freedom, safety and happiness. Technology allows for the increases in productivity enabling human progress. DiEM25 firmly supports sound and positive technological development that benefits mankind, and rejects Luddite anti-technological thinking.
+
+3. There is always a choice.
+
+What does that mean?
+
+Every technological development is the result of choices. Choices made by governments, investors, consumers, manufacturers, distributors and many others. No technology is god-given or invisible hand-given. No technology is unavoidable or un-opposable. DiEM25 believes that, as a society, we have the duty to be aware of the fact that we make choices on technology. Choices on technical standards. On interoperability. On ownership and use of technology. On control and regulation of technology.
+Those choices, and the debate around them, must become visible to the public eye, and exposed on the public platform.
+DiEM25 firmly supports democracy and rejects technocracy.
+
+4. There is no such thing as a free lunch
+
+What does that mean?
+
+Everything comes at a cost. Also technology. There are at least three inherent costs of technology. The first cost is that every technology requires initial investment. When that investment comes from the state or another collective, it must be recognized and rewarded. The second cost is that, by selecting or benefiting one technology over another, someone always loses out. It is a hidden cost, paid by the beneficiaries of the technology we choose not to develop. The third is the cost related to creating and using a technology. From pollution to traffic victims, many people pay a heavy price for technology. DiEM25 wants society to recognize the costs of technology to society, in addition to its benefits. Then, both costs and benefits need to be properly allocated and/or compensated.
+
+5. Value is in sharing
+
+What does that mean?
+
+Technology is the result of value creation, and, in turn, enables the creation of more value. But value does not stand by itself. Value exists in relation to other things, and to people. Artificial boundaries that block or slow down the creative sharing of technology damage society. The more value and technology are shared; the more they can create value in return. By sharing technology and knowledge, society ensures that much more value is created than by “protecting” it. DiEM25 firmly supports sharing technology, and rejects monopolies or rent seeking.
+
+6. There is no natural distribution of the proceeds of technology
+
+What does that mean? 
+
+The “invisible hand” is a dogma, and it does not actually exist. The proceeds of technology originate from the whole of society – no inventor is an island. Sharing the proceeds of technology across society is a matter of essential fairness. This is because non-regulated systems are structurally not capable to provide a fair and just distribution of the proceeds of technology.
+Therefore, we must establish rules on how the proceeds of technological process benefit all different parts of society. That is a quintessential democratic process: the clash of different interest groups must be done openly, through debate, with enforceable rules of engagement.
+DiEM25 strongly believes that the decision on allocation of the proceeds of technological development must be openly and democratically discussed. DiEM25 firmly rejects the dogma of the invisible hand.
+
+7. We stand on the shoulders of giants
+
+What does that mean?
+
+Technology does not fall from the sky. For tens of thousands of years, humans have made incremental progress in developing technology. It is the result of collaboration and co-operation between many. The knowledge handed down from our ancestors is absolutely necessary for us to build on it. And just like we borrowed that knowledge from our ancestors, we need to pass it on to the next generations.
+DiEM25 rejects artificial boundaries around knowledge, and wants to ensure that continued progress remains possible through the sharing of both old and new knowledge.
+
+8. No Frankenstein - principle
+
+What does that mean?
+
+Our society is becoming ever more complex, as is our technology. 50 years ago, a well-trained engineer could understand, and repair, a lot of technology. That is no longer the case. With hyper-specialization comes hyper-mutual dependency. Sometimes we don’t understand fully the technology we create. Therefore, the myth of the sole genius solving a fundamental problem in his (never, by the way, “her”) basement is no longer useful – quite the opposite.
+The ever increased specialization and complexity of technology makes it necessary for our society to open up as much information as possible about how things work – so we are able to understand what goes wrong when something goes wrong. As it inevitably will.
+DiEM25 rejects the Frankenstein myth as a workable basis for developing and maintaining knowledge and innovation. An ever more complex and specialized society and technology demands as much open knowledge and communication as possible.
+
+9. Technology reflects our values
+
+What does that mean?
+
+Technology is never value-free. The way we fund, adopt, use and regulate technology, or not, reflects society’s choice of its values and priorities. E.g. we currently accept that thousands of children are killed every year through society’s incoherent approach to the use of transportation technology. That is a reflection of our society’s priorities and values. We must be more aware of how choices around technology must be rooted in values, and openly discuss and decide on them in a democratic way. The agenda setting of the debate around technology and values should be open, and not set by the technology industry itself. DiEM25 strongly supports open and healthy discussions on the values that are reflected through our choices around technology, and firmly rejects the notion of value-free technology. Negative values such as corruption, fraud or privilege are not acceptable, and technology may not be used to defend or strengthen them
+
+10. Technology solves technical problems, not human ones
+
+What does that mean?
+
+Technological messianism is not the right approach. Technology is a tool that can help to solve technical problems. But it is humans who must direct how technology is used, and its purpose must be to solve human problems. Justice, equality, fairness, or the lack thereof, will not be solved by technology alone. Without human and moral guidance technology has as much opportunity to make problems worse rather than better. Already, we see how prejudice and bias can be strengthened through technology, making technology part of the problem, rather than the solution. In the end, technology is and remains a tool. And we must choose how to use it. DiEM25 believes that technology must be used as a tool to address problems of human society, and firmly rejects technological messianism.
+
+# 12
+## 06.07.2018 Annette Fröhlich, Harry Unger, DSC Wiesbaden - 18-07-06
+
+Arbeitskraft und Daten
+
+Früher war die Arbeitskraft das Kapital der Arbeiterinnen und Arbeiter, dies hat sich in den letzten 25 Jahren stark zum Nachteil der Arbeiterinnen und Arbeiter verändert. Durch die Informationstechnologie und Robotik wurden und werden die Arbeiterinnen und Arbeiter immer mehr ihres Kapitals beraubt. Aber nicht nur dass sie ihres Kapitals beraubt werden, die neue Ausbeutung der Arbeiterinnen und Arbeiter hat ein gigantisches Ausmaß angenommen. Durch das Sammeln und Verwerten ihrer Daten werden die Arbeiterinnen und Arbeiter massiv ausgebeutet und entrechtet. Wir von DiEM 25 müssen uns für die Wiedereinsetzung der Rechte der Arbeiterinnen und Arbeiter einsetzen und dafür Sorge tragen, dass ihnen auch ihr Kapital zurückgegeben wird. Das sollte dadurch geschehen, dass alle Unternehmen, die in irgendeiner Form Daten ihrer Kunden erheben und speichern, dem Menschen der die Daten zur Verfügung stellt etwas bezahlen. Die Höhe des Betrages sollte durch Art und Menge der Daten geregelt sein. Lediglich zum Zwecke der Regelung interner Abläufe dürfen Daten ohne Entschädigung erhoben werden. Diese Daten dürfen dann aber nicht weitergegeben oder weiterverarbeitet werden. Dies müssen die Unternehmen in einer Erklärung gegenüber dem Menschen zusichern. Die Einnahmen durch bereitstellen von Daten durch Arbeiterinnen und Arbeiter kann dann auf das Einkommen aufgerechnet und entsprechend versteuert werden.
+Monat für Monat werden weltweit Milliarden Euro Gewinne abgeschöpft, diese Gewinne werden durch Datenausbeutung erzielt und müssen endlich an die Menschen zurückgegeben werden, denen diese Gewinne zustehen.
+
+Work force and data
+
+In the past, labour was the capital of workers, and this has changed greatly over the last 25 years to the detriment of workers. Information technology and robotics have increasingly deprived workers of their capital. But not only are they being deprived of their capital, the new exploitation of the workers has taken on a gigantic scale. By collecting and using their data, the workers are massively exploited and deprived of their rights. We at DiEM25 must work for the restoration of workers' rights and ensure that their capital is also returned to them. This should be done by all companies that collect and store data of their customers in any form paying something to the person who makes the data available. The amount should be determined by the type and amount of data. Data may only be collected without compensation for the purpose of regulating internal processes. However, this data may not be passed on or further processed. This must be assured by the companies in a declaration to the people. The income from the provision of data by workers can then be offset against their income and taxed accordingly.
+Every month billions of euros of profits are skimmed off worldwide, these profits are made through data exploitation and must finally be returned to the people who are entitled to these profits.
+
+
+# 13 
+## 07.07.2018 Addition to proposal Autonomous Data Network Arne Babenhauserheide - 18-07-07
+
+I read your article about Technological Sovereignty (https://diem25berlin.org/news-from-the-pillars-questionnaire-technological-souvereignty/) and was intrigued by your writing on encouraging research on an open-source and easy-to-use solution for an Autonomous Data Network. I am the current release manager of the Freenet Project, which provides fully decentralized, encrypted, censorship resistant data sharing using only free open source software. 
+http://freenetproject.org 
+
+Freenet was started 1999 and has seen continuous improvements since then, to some part supported by donations, nowadays mostly supported by voluntary work (I’m also a volunteer). In 2015 it won the SUMA award for protection against total surveillance. Different from every other network, Freenet provides solutions to decentralized spam detection and prevention which have stood the test of keeping communication working well while providing fully anonymous communication for over a decade. And it can be used without any central point of failure. It can be used — and is already being used — as backend for diverse applications, from chat over forums to email and games, as well as publishing websites which stay online as long as people are interested in them. Anything which works with a shared database and can tolerate about 1 minute latency can use Freenet as backend. That does not mean that Freenet is perfect. But I strongly believe that it is the best we have with the strongest conceptual foundation (otherwise I would not work on it). You can find my personal writings on Freenet on my private homepage: http://www.draketo.de/stichwort/freenet 
+
+The central articles are: 
+
+- A commentary: "Freenet: The forgotten cryptopunk paradise": http://www.draketo.de/english/freenet/forgotten-cryptopunk-paradise 
+- Using Freenet to regain confidential communication with friends:
+http://www.draketo.de/english/freenet/connect-speak-freely 
+- How to use Freenet as backend for other applications: http://www.draketo.de/light/english/freenet/communication-primitives-1-files-and-sites 
+- Freenet allows sharing invisible, password protected files: http://www.draketo.de/light/english/freenet/effortless-password-protected-sharing-files 
+- Freenet anonymity: Best case and Worst case: http://www.draketo.de/light/english/freenet/anonymity-best-case-and-worst-case 
+- A proposal to make Freenet better suited for Journalists: http://www.draketo.de/light/english/freenet/freenet-journalists-funding-proposal 
+- A proposal for sharing news without outside corruption: http://www.draketo.de/english/freenet/news-of-the-day 
+
+I would like to answer more of your questions about tech and copyright, but this email already required the free time I had for this evening, so I’ll sadly have to call it a night. I hope my email helps you in creating better tech policy!
+
+
+# 14 
+## 07.07.2018 Proposal for a „Citizen’s Research and Innovation platform“ - DSC Karlsruhe - 18.07.07
+
+This is our proposal that addresses the questions of how to democratise the funding of research and innovation and how to give citizen’s a stronger say in defining problems that should be addressed through research and innovation with the help of a digital platform and the idea of digital direct democracy.
+This proposal is based on the idea of the European Green New Deal that there will be much more mission-oriented public funding for research and innovation, e.g. a European Innovation Fund.
+
+Citizen crowd funding
+
+The platform needs to contain a crowd funding system that allows European citizens to allocate public money through their decisions on the platform. Every EU citizen that uses the platform has the right to allocate the same amount of public money to research or innovation projects (technological, social and cultural innovation). The projects apply with their proposals and a sum of money that would allow them to start the work. As in crowdfunding if enough citizens give money to a proposed project it is successful and gets money from the fund. The potential strength of crowd funding over voting is that it allows for greater diversity in the successful projects, i.e. even if only 10 % of the citizens support a project it can still be successful if it raises enough money through these 10 % of citizens. Through voting only projects that get more than 50 % of support would be successful.
+A reasonable amount of money from public funds for research and innovation needs to be put into this platform to give citizens an actual say in shaping the trajectories of research and innovation. One third of the overall EU budget for research and innovation or of the European Innovation Fund, i.e. several billions €, seems reasonable. The other two thirds could be allocated as usual through the science system or through parliament.
+
+Citizen’s needs crowdsourcing
+
+The platform should also entail the function for citizens to name and describe problems and needs that they feel should be solved through research and innovation. While the problems are openly sourced there would also be a form of voting on the platform to rank these. The top ranking problems are then turned into pillars for the funding side of the platform such that researchers and innovators can apply with their proposals for these. More localised forms of problem sourcing and money allocation could be introduced in the platform as well.
+
+Ensure Participation
+
+It seems unlikely that an equally distributed group of Europeans participate in this platform if it is simply open to all citizens. As in most forms of citizen participation well educated and higher earning people would probably dominate the platform. Therefore particular procedures need to be devised that ensure that a representative group of European citizens is active on the platform and shapes the decisions. This could be done through drawing several thousand citizens from Europe by lot – and by paying them a sum of money as compensation for participating. Furthermore, the platform needs to have its content in all languages of the European Union.
+
+
+# 15 
+## 10.07.2018 Labor Intelligence / Shared Worker Governance / Cooperative Intelligence - Kate McCurdy - 18-07-10
+
+problem:
+
+large scale intelligent systems for managing labor, e.g. scheduling / logistics, are developed under private control without necessary regard for worker concerns, such as dignity, autonomy, predictability, etc - and are used in ways that directly encroach upon worker dignity and privacy on and off the job.
+
+statement:
+
+the EU should have a dedicated fund - perhaps an institute - working specifically at the intersection of AI and labor
+
+aims:
+
+	- explore + prototype intelligent systems with various axes of worker control (i.e. ranging  from 'being designed along worker-friendly principles' to 'responsive to real-time  worker input' to 'explicity includes coorperative decision mechanism for key decisions')
+	- partner with existing organizations, perhaps companies but particularly **cooperatives**, to  apply + test systems under real-world conditions
+	- assess outcomes with particular attention to humanistic goals, quality of life, and  worker-centered perspectives
+	- particular attention to: barriers faced by marginalized workers / workers from  traditionally excluded background
+	- system evaluation always conducted from at least two vantage points:
+		- "average"/broadly representative worker
+		- most vulnerable worker (i.e. subject to most intersecting constraints on her exercise of  autonomy in labor sphere)
+
+# 16 
+## 10.07.2018 Public Digital Identity - Kate McCurdy - 18.07.10
+
+problem:
+
+- identity management tied to state risks surveillance BUT left to corporations -> private  surveillance (e.g. goog/fb have profiles on people who have not created accounts with  them), ensures unaccountability / loss of control from user
+
+statement:
+
+the EU should develop a free public system for digital identity management 
+
+aims:
+
+- connect identity with data across platforms
+- allow to selectively share data with platforms, see which data is available, revoke access  if necessary
+- distributed ledger (i.e. blockchain) = not centralized / subject to state / corporate  manipulation
+- highly restricted access for the state:
+- decoupled from other forms of national identity (e.g. SSN, tax ID)
+- accessible only under very particular, narrowly legally defined circumstances
+- keep anonymous / decoupled from essential services
+- periodic independent review of state use of identity management system to highlight  potential areas of abuse
+- standard format for data management / identity sharing -> lower barrier to entry for  small businesses / startups to build services
+
+# 17 
+## 11.07.2018 Proposal - several - Carlo von Lynx
+
+Regarding "Democratising technologies" 1-9, I wrote up a new document at https://youbroketheinternet.org/programme (related to #ObCrypto) --- please throw any criticism at me so I can work it in.
+
+Regarding "Democratising technologies" 10, women say they experienced better inclusion when using liquid democracy: http://my.pages.de/liquidspin
+
+Re "Democratising Research and Innovation", the EU insists on funding things that have a business model, cutting out projects that are intended to do good for society.
+
+Re "Copyright", please look at the copyright reforms proposed by the German Pirate Party (not to be confused with those of the Swedish Pirate Party).
+
+Re "Peer review system", I wouldn't be surprised if liquid democracy could make these things more corruption-resistant.
+
+Re "AI for common good" I have a simple recommendation: make it impossible to collect social/private data of human beings so that AI cannot be applied to it. See first link.
+
+Re "Investing in European tech for the public interest" -- regulating a secure open Internet running on trustworthy hardware makes it likely that such trustworthy hardware would need to be produced in Europe.
+


### PR DESCRIPTION
This pull request has a markdown document containing all proposals as gathered in this [onlyoffice document](https://personal.onlyoffice.com/products/files/doceditor.aspx?fileid=2450371&doc=dThDcFZBdlZnYXlNUlRTNjJVbnR1YUw2bDdGRVNoRHpxOVVjMVFOWDFKQT0_IjI0NTAzNzEi0#).

I've attempted to preserve some formatting, but much of it hasn't made the transition / requires a bit of markdown-ification to look decent again.

Comments have been brought over and added as comments on the pull request, which means:

- if the pull request is merged, the comments will not come along for the ride; they could be recreated on the files if we see the need, otherwise they'll stay only within this PR view
- if the line referenced by a comment is deleted, the comment will be gone as well

so there may be room for improvements, but I don't see any problem with keeping this PR open as long as needed, so let's start trying out collaboration here and iterate as needed!